### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Combines machine learning with full-stack development for a smarter, more intuit
 ## 🌐 Live Demo
 - 🔗 Try SmartBasket
 - First, visit the following link to spin up back-end deployment: https://smartbasket-u8bn.onrender.com
-- Once back-end has lauched, visit the following link to access the web app: https://smartbasket-frontend.onrender.com
+- Once back-end has launched, visit the following link to access the web app: https://smartbasket-frontend.onrender.com
 - 🧪 Test Credentials:
 - Login: Test
 - Password: test


### PR DESCRIPTION
## Summary
- fix typo in Live Demo section

## Testing
- `grep -n "Once back-end" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_684f99b0c800832da25225331c6d40df